### PR TITLE
Fix serializeJson()

### DIFF
--- a/lib/serialize/json/serializeMapping.js
+++ b/lib/serialize/json/serializeMapping.js
@@ -28,6 +28,7 @@
  */
 
 var xml = require('xml'),
+    extend = require('extend'),
     serializeIdentified = require('./serializeIdentified');
 
 module.exports = function serializeMapping(sbolDocument, mapping) {

--- a/lib/serialize/json/serializeModuleDefinition.js
+++ b/lib/serialize/json/serializeModuleDefinition.js
@@ -32,6 +32,7 @@
 var extend = require('extend'),
     serializeIdentified = require('./serializeIdentified'),
     serializeFunctionalComponent = require('./serializeModule'),
+    serializeModule = require('./serializeModule'),
     serializeFunctionalComponent = require('./serializeFunctionalComponent'),
     serializeInteraction = require('./serializeInteraction');
 


### PR DESCRIPTION
This is the patch I created to solve the two missing imports on 
https://github.com/SynBioDex/sboljs/issues/47

In serialiseModuleDefinition I had to add a double import ( maybe there is a cleaner solution but I didn't want to mess with the logic of the file)

```
    serializeFunctionalComponent = require('./serializeModule'),
    serializeModule = require('./serializeModule'),
```

I hope this helps

Thanks